### PR TITLE
Fix migration rollback and improve validation and documentation

### DIFF
--- a/src/SnackFlow.Api/Attributes/RequirePermissionAttribute.cs
+++ b/src/SnackFlow.Api/Attributes/RequirePermissionAttribute.cs
@@ -2,6 +2,13 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace SnackFlow.Api.Attributes;
 
+/// <summary>
+/// Atributo personalizado para autorização baseada em permissões.
+/// IMPORTANTE: Herda de AuthorizeAttribute para que o ASP.NET reconheça como atributo de autorização.
+/// </summary>
+/// <remarks>
+/// Fluxo: [RequirePermission] → Formata Policy → PermissionPolicyProvider → PermissionAuthorizationHandler → Autoriza/Nega
+/// </remarks>
 public sealed class RequirePermissionAttribute : AuthorizeAttribute
 {
     public RequirePermissionAttribute(params string[] permissions)

--- a/src/SnackFlow.Api/Authorizations/Permissions/PermissionPolicyProvider.cs
+++ b/src/SnackFlow.Api/Authorizations/Permissions/PermissionPolicyProvider.cs
@@ -3,6 +3,15 @@ using Microsoft.Extensions.Options;
 
 namespace SnackFlow.Api.Authorizations.Permissions;
 
+/// <summary>
+/// Provider responsável por criar políticas de autorização dinamicamente baseadas em permissões.
+/// Intercepta policies no formato "RequirePermissions:perm1,perm2" e cria automaticamente.
+/// </summary>
+/// <remarks>
+/// Evita ter que registrar manualmente cada combinação de permissões no Program.cs.
+/// Para policies que não seguem o padrão, delega para o DefaultAuthorizationPolicyProvider.
+/// </remarks>
+/// <param name="options">Opções de autorização do ASP.NET Core</param>
 public sealed class PermissionPolicyProvider(IOptions<AuthorizationOptions> options) 
     : IAuthorizationPolicyProvider
 {

--- a/src/SnackFlow.Application/DependencyInjection.cs
+++ b/src/SnackFlow.Application/DependencyInjection.cs
@@ -22,7 +22,10 @@ public static class DependencyInjection
                 typeof(LoggingBehavior<,>),
             ];
         });
-        
-        services.AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly);
+
+        services.AddValidatorsFromAssembly(
+            typeof(DependencyInjection).Assembly,
+            includeInternalTypes: true
+        );
     }
 }

--- a/src/SnackFlow.Application/Features/Users/Commands/CreateUser/CreateUserCommandValidator.cs
+++ b/src/SnackFlow.Application/Features/Users/Commands/CreateUser/CreateUserCommandValidator.cs
@@ -21,7 +21,9 @@ internal sealed class CreateUserCommandValidator : AbstractValidator<CreateUserC
         
         RuleFor(x => x.Position)
             .NotNull()
-            .WithMessage("O cargo deve ser preenchido.");
+            .WithMessage("O cargo deve ser preenchido.")
+            .IsInEnum()
+            .WithMessage("O cargo informado não é válido.");
 
         When(x => x.CompanyId.HasValue, () =>
         {

--- a/src/SnackFlow.Infrastructure/Persistence/Migrations/20250719221553_AddQuartzTables.cs
+++ b/src/SnackFlow.Infrastructure/Persistence/Migrations/20250719221553_AddQuartzTables.cs
@@ -11,26 +11,6 @@ namespace SnackFlow.Infrastructure.Persistence.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql(@"
-                DO $$
-                  DECLARE DropDb INT := 1; -- Set this to 0 to skip DROP statements, 1 to include them
-                BEGIN
-                  IF DropDb = 1 THEN
-                    SET client_min_messages = WARNING;
-                    DROP TABLE IF EXISTS qrtz_fired_triggers;
-                    DROP TABLE IF EXISTS qrtz_paused_trigger_grps;
-                    DROP TABLE IF EXISTS qrtz_scheduler_state;
-                    DROP TABLE IF EXISTS qrtz_locks;
-                    DROP TABLE IF EXISTS qrtz_simprop_triggers;
-                    DROP TABLE IF EXISTS qrtz_simple_triggers;
-                    DROP TABLE IF EXISTS qrtz_cron_triggers;
-                    DROP TABLE IF EXISTS qrtz_blob_triggers;
-                    DROP TABLE IF EXISTS qrtz_triggers;
-                    DROP TABLE IF EXISTS qrtz_job_details;
-                    DROP TABLE IF EXISTS qrtz_calendars;
-                    SET client_min_messages = NOTICE;
-                  END IF;
-                END $$;
-
                 CREATE TABLE qrtz_job_details
                   (
                     sched_name TEXT NOT NULL,
@@ -197,7 +177,27 @@ namespace SnackFlow.Infrastructure.Persistence.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-
+            migrationBuilder.Sql(@"
+                DO $$
+                  DECLARE DropDb INT := 1; -- Set this to 0 to skip DROP statements, 1 to include them
+                BEGIN
+                  IF DropDb = 1 THEN
+                    SET client_min_messages = WARNING;
+                    DROP TABLE IF EXISTS qrtz_fired_triggers;
+                    DROP TABLE IF EXISTS qrtz_paused_trigger_grps;
+                    DROP TABLE IF EXISTS qrtz_scheduler_state;
+                    DROP TABLE IF EXISTS qrtz_locks;
+                    DROP TABLE IF EXISTS qrtz_simprop_triggers;
+                    DROP TABLE IF EXISTS qrtz_simple_triggers;
+                    DROP TABLE IF EXISTS qrtz_cron_triggers;
+                    DROP TABLE IF EXISTS qrtz_blob_triggers;
+                    DROP TABLE IF EXISTS qrtz_triggers;
+                    DROP TABLE IF EXISTS qrtz_job_details;
+                    DROP TABLE IF EXISTS qrtz_calendars;
+                    SET client_min_messages = NOTICE;
+                  END IF;
+                END $$;
+            ");
         }
     }
 }


### PR DESCRIPTION
```
### Description

- Restored logic to drop Quartz tables during migration rollback for consistency.
- Added `IsInEnum` validation to ensure `Position` is within the enum range in `CreateUserCommandValidator`.
- Updated Dependency Injection to allow internal types for validator discovery.
- Added XML documentation for `PermissionPolicyProvider` and `RequirePermissionAttribute` to clarify dynamic authorization and usage.

### Checklist

- [ ] Tests added for changes
- [ ] Documentation updated (if needed)
- [ ] Code follows coding standards
- [ ] Ready for review
```